### PR TITLE
Fix missing PostCSS configuration

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};


### PR DESCRIPTION
## Summary
- fix missing `postcss.config.js` so Vite processes TailwindCSS

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684dd5fc32dc83338ea96402db5475be