### PR TITLE
Fix buyer layout and add route prefixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "project",
+  "name": "eco-jara",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -14,13 +14,13 @@ import Settings from './components/Settings.vue';
 
 // Setup router
 const routes = [
-    { path: '/', redirect: '/login' },
-    { path: '/login', component: Login, name: 'login' },
-    { path: '/dashboard', component: Dashboard, name: 'dashboard' },
-    { path: '/marketplace', component: Marketplace, name: 'marketplace' },
-    { path: '/certificates', component: Certificates, name: 'certificates' },
-    { path: '/reports', component: Reports, name: 'reports' },
-    { path: '/settings', component: Settings, name: 'settings' }
+    { path: '/', redirect: '/seller/login' },
+    { path: '/seller/login', component: Login, name: 'login' },
+    { path: '/seller/dashboard', component: Dashboard, name: 'dashboard' },
+    { path: '/seller/marketplace', component: Marketplace, name: 'marketplace' },
+    { path: '/seller/certificates', component: Certificates, name: 'certificates' },
+    { path: '/seller/reports', component: Reports, name: 'reports' },
+    { path: '/seller/settings', component: Settings, name: 'settings' }
 ];
 
 const router = createRouter({

--- a/resources/js/components/Layout.vue
+++ b/resources/js/components/Layout.vue
@@ -20,7 +20,7 @@
           :to="item.href"
           :class="[
             'sidebar-link',
-            $route.name === item.href.substring(1) ? 'active' : ''
+            $route.path === item.href ? 'active' : ''
           ]"
         >
           <component :is="item.icon" class="w-5 h-5 mr-3" />
@@ -104,15 +104,15 @@ import {
 const route = useRoute();
 
 const navigation = [
-  { name: 'Dashboard', href: '/dashboard', icon: HomeIcon },
-  { name: 'Marketplace', href: '/marketplace', icon: ShoppingBagIcon },
-  { name: 'Certificates', href: '/certificates', icon: DocumentDuplicateIcon },
-  { name: 'Reports', href: '/reports', icon: ChartBarIcon },
-  { name: 'Settings', href: '/settings', icon: CogIcon },
+  { name: 'Dashboard', href: '/seller/dashboard', icon: HomeIcon },
+  { name: 'Marketplace', href: '/seller/marketplace', icon: ShoppingBagIcon },
+  { name: 'Certificates', href: '/seller/certificates', icon: DocumentDuplicateIcon },
+  { name: 'Reports', href: '/seller/reports', icon: ChartBarIcon },
+  { name: 'Settings', href: '/seller/settings', icon: CogIcon },
 ];
 
 const currentPageTitle = computed(() => {
-  const currentNav = navigation.find(item => item.href === `/${route.name}`);
+  const currentNav = navigation.find(item => item.href === route.path);
   return currentNav ? currentNav.name : 'Dashboard';
 });
 </script>

--- a/resources/js/components/Login.vue
+++ b/resources/js/components/Login.vue
@@ -118,7 +118,7 @@ const handleLogin = async () => {
     loading.value = false;
     // For demo purposes, always succeed
     localStorage.setItem('auth_token', 'demo_token');
-    router.push('/dashboard');
+    router.push('/seller/dashboard');
   }, 1500);
 };
 </script>

--- a/resources/js/components/buyer/BuyerLayout.vue
+++ b/resources/js/components/buyer/BuyerLayout.vue
@@ -1,1 +1,90 @@
-{"code":"rate-limited","message":"You have hit the rate limit. Please <a class=\"__boltUpgradePlan__\">Upgrade</a> to keep chatting, or you can continue coding for free in the editor.","providerLimitHit":false,"isRetryable":true}
+<template>
+  <div class="flex h-screen bg-gray-50">
+    <!-- Sidebar -->
+    <div class="sidebar-gradient w-64 flex flex-col">
+      <!-- Logo -->
+      <div class="flex items-center px-6 py-6 border-b border-white border-opacity-20">
+        <div class="w-8 h-8 bg-white rounded-lg flex items-center justify-center mr-3">
+          <svg class="w-5 h-5 text-primary-teal" fill="currentColor" viewBox="0 0 20 20">
+            <path fill-rule="evenodd" d="M10 2L3 7v11a1 1 0 001 1h12a1 1 0 001-1V7l-7-5z" clip-rule="evenodd"/>
+          </svg>
+        </div>
+        <h1 class="text-xl font-bold text-white">Ecojarah</h1>
+      </div>
+
+      <!-- Navigation -->
+      <nav class="flex-1 py-6">
+        <router-link
+          v-for="item in navigation"
+          :key="item.name"
+          :to="item.href"
+          :class="[
+            'sidebar-link',
+            $route.path === item.href ? 'active' : ''
+          ]"
+        >
+          <component :is="item.icon" class="w-5 h-5 mr-3" />
+          {{ item.name }}
+        </router-link>
+      </nav>
+
+      <!-- User Profile -->
+      <div class="p-4 border-t border-white border-opacity-20">
+        <div class="flex items-center">
+          <img class="w-10 h-10 rounded-full" src="https://images.pexels.com/photos/774909/pexels-photo-774909.jpeg?w=100&h=100&fit=crop&crop=face" alt="Mira Bassem">
+          <div class="ml-3">
+            <p class="text-sm font-medium text-white">Mira Bassem</p>
+            <p class="text-xs text-gray-300">UI/UX Designer</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Main Content -->
+    <div class="flex-1 flex flex-col overflow-hidden">
+      <!-- Header -->
+      <header class="bg-white shadow-sm border-b border-gray-200">
+        <div class="flex items-center justify-between px-6 py-4">
+          <div class="flex items-center">
+            <h2 class="text-xl font-semibold text-gray-800">{{ currentPageTitle }}</h2>
+          </div>
+          <div class="flex items-center space-x-4">
+            <!-- Placeholder for header actions -->
+          </div>
+        </div>
+      </header>
+
+      <!-- Page Content -->
+      <main class="flex-1 overflow-auto">
+        <slot />
+      </main>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { useRoute } from 'vue-router';
+import {
+  HomeIcon,
+  ShoppingBagIcon,
+  DocumentDuplicateIcon,
+  ChartBarIcon,
+  CogIcon,
+} from '@heroicons/vue/24/outline';
+
+const route = useRoute();
+
+const navigation = [
+  { name: 'Dashboard', href: '/buyer/dashboard', icon: HomeIcon },
+  { name: 'Marketplace', href: '/buyer/marketplace', icon: ShoppingBagIcon },
+  { name: 'Certificates', href: '/buyer/certificates', icon: DocumentDuplicateIcon },
+  { name: 'Reports', href: '/buyer/reports', icon: ChartBarIcon },
+  { name: 'Settings', href: '/buyer/settings', icon: CogIcon },
+];
+
+const currentPageTitle = computed(() => {
+  const currentNav = navigation.find(item => item.href === route.path);
+  return currentNav ? currentNav.name : 'Dashboard';
+});
+</script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,28 +3,30 @@
 use Illuminate\Support\Facades\Route;
 
 // Seller routes
-Route::get('/login', function () {
-    return view('app');
-});
+Route::prefix('seller')->group(function () {
+    Route::get('/login', function () {
+        return view('app');
+    });
 
-Route::get('/dashboard', function () {
-    return view('app');
-});
+    Route::get('/dashboard', function () {
+        return view('app');
+    });
 
-Route::get('/marketplace', function () {
-    return view('app');
-});
+    Route::get('/marketplace', function () {
+        return view('app');
+    });
 
-Route::get('/certificates', function () {
-    return view('app');
-});
+    Route::get('/certificates', function () {
+        return view('app');
+    });
 
-Route::get('/reports', function () {
-    return view('app');
-});
+    Route::get('/reports', function () {
+        return view('app');
+    });
 
-Route::get('/settings', function () {
-    return view('app');
+    Route::get('/settings', function () {
+        return view('app');
+    });
 });
 
 // Buyer routes


### PR DESCRIPTION
## Summary
- repair `BuyerLayout.vue` after corruption
- prefix seller dashboard routes with `/seller`
- update seller navigation and login redirect
- add matching buyer navigation component
- update route definitions for seller prefix

## Testing
- `npm install`
- `npm run build`
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684eb05669388333befe6c8e916c5a51